### PR TITLE
Lilcatalog url update

### DIFF
--- a/src/apps/lilcatalog/lilcatalog.cpp
+++ b/src/apps/lilcatalog/lilcatalog.cpp
@@ -8,8 +8,7 @@ LilCatalogApp::LilCatalogApp() : App(LILCATALOG_S_APP) {
     setStackSize(8192);
     path_catalog_folder = "/lilcatalog";
     path_catalog_file = "/lilcatalog/catalog.json";
-    catalog_url = "https://raw.githubusercontent.com/lilka-dev/lilka/refs/heads/main/firmware/keira/src/apps/"
-                  "lilcatalog/catalog.json";
+    catalog_url = "https://raw.githubusercontent.com/lilka-dev/keira/refs/heads/main/src/apps/lilcatalog/catalog.json";
 }
 
 void LilCatalogApp::run() {


### PR DESCRIPTION
fixes inability to download catalog.json, cause we moved to another repo, and it's located in a new place now