### PR TITLE
Added KEIRA_DEBUG_APP and KEIRA_DEBUG_APP_PARAMS macroses

### DIFF
--- a/src/apps/launcher.cpp
+++ b/src/apps/launcher.cpp
@@ -52,6 +52,13 @@ LauncherApp::LauncherApp() : App("Menu") {
 }
 
 void LauncherApp::run() {
+#ifdef KEIRA_DEBUG_APP
+#    ifdef KEIRA_DEBUG_APP_PARAMS
+    this->runApp<KEIRA_DEBUG_APP>(KEIRA_DEBUG_APP_PARAMS);
+#    else
+    this->runApp<KEIRA_DEBUG_APP>();
+#    endif
+#endif
     for (lilka::Button button : {lilka::Button::UP, lilka::Button::DOWN, lilka::Button::LEFT, lilka::Button::RIGHT}) {
         lilka::controller.setAutoRepeat(button, 10, 300);
     }

--- a/src/apps/launcher.cpp
+++ b/src/apps/launcher.cpp
@@ -95,16 +95,11 @@ void LauncherApp::run() {
                         &app_group_img, 0
                     ),
                     ITEM::APP(K_S_LAUNCHER_LILCATALOG, [this]() { this->runApp<LilCatalogApp>(); }),
-                    ITEM::APP(K_S_LAUNCHER_LILTRACKER, [this]() {
-        this->runApp<LilTrackerApp>(); }),
-                    ITEM::APP(K_S_LAUNCHER_LETRIS, [this]() {
-        this->runApp<LetrisApp>(); }),
-                    ITEM::APP(K_S_LAUNCHER_TAMAGOTCHI, [this]() {
-        this->runApp<TamagotchiApp>(); }),
-                    ITEM::APP(K_S_LAUNCHER_WEATHER, [this]() {
-        this->runApp<WeatherApp>(); }),
-                    ITEM::APP(K_S_LAUNCHER_PASTEBIN, [this]() {
-        this->runApp<pastebinApp>(); }),
+                    ITEM::APP(K_S_LAUNCHER_LILTRACKER, [this]() { this->runApp<LilTrackerApp>(); }),
+                    ITEM::APP(K_S_LAUNCHER_LETRIS, [this]() { this->runApp<LetrisApp>(); }),
+                    ITEM::APP(K_S_LAUNCHER_TAMAGOTCHI, [this]() { this->runApp<TamagotchiApp>(); }),
+                    ITEM::APP(K_S_LAUNCHER_WEATHER, [this]() { this->runApp<WeatherApp>(); }),
+                    ITEM::APP(K_S_LAUNCHER_PASTEBIN, [this]() { this->runApp<pastebinApp>(); }),
                 },
                 &demos_img,
                 lilka::colors::Pink


### PR DESCRIPTION
This feature allows to autorun specified application which could significantly improve speed of new apps debugging, allowing to control it through environment variables or platformio.ini build_flags.

Usage example:

```
PLATFORMIO_BUILD_FLAGS='-DKEIRA_DEBUG_APP=BallApp' pio run -e v2 -t upload
```

or even more funky

```
PLATFORMIO_BUILD_FLAGS='-DKEIRA_DEBUG_APP=FileManagerApp -DKEIRA_DEBUG_APP_PARAMS=\"/spiffs\"' pio run -e v2 -t upload
```

Am not sure about multiple params, cause macro 've some limitations, though, with single one it works perfect