### PR TITLE
docs: update clone instructions after removal of submodules

### DIFF
--- a/docs/flashing.rst
+++ b/docs/flashing.rst
@@ -10,14 +10,14 @@
 Клонування репозиторію та побудова прошивки
 -------------------------------------------
 
-1. Перейдіть на вкладку **Source Control** (``Ctrl`` + ``Shift`` + ``G``) та клонуйте репозиторій `Lilka <https://github.com/lilka-dev/lilka>`_:
+1. Перейдіть на вкладку **Source Control** (``Ctrl`` + ``Shift`` + ``G``) та клонуйте репозиторій `Lilka <https://github.com/lilka-dev/keira>`_:
 
    .. image:: ./images/08_clone_repo_cropped.png
        :width: 80%
 
    Для цього натисніть "**Clone Repository**" та введіть адресу репозиторію:
 
-   ``https://github.com/lilka-dev/lilka``
+   ``https://github.com/lilka-dev/keira``
 
    .. image:: ./images/09_clone_cropped.png
        :width: 80%


### PR DESCRIPTION
This PR updates the “Клонування репозиторію та побудова прошивки” section of the Flashing guide.

**Problem:**  
The current instructions rely on cloning the mono repository (`https://github.com/lilka-dev/lilka`) and using Git submodules. However, [commit 05f9a521](https://github.com/lilka-dev/lilka/commit/05f9a521137cf75d87a085f1790a148105fb960c) removed all submodules from the monorepo, making the old steps outdated and potentially confusing or broken for users.

**Changes:**  
- Adjusted the clone URL to point directly to the new repository

**Impact:**  
This will prevent confusion or build failures for users following the flashing instructions on the website.