### PR TITLE
Improve rendering via direct framebuffer usage

### DIFF
--- a/src/apps/nes/driver.cpp
+++ b/src/apps/nes/driver.cpp
@@ -89,24 +89,74 @@ void Driver::customBlit(bitmap_t* bmp, int numDirties, rect_t* dirtyRects) {
 #ifdef INTERLACED
     for (int y = odd ? 1 : 0; y < frame_height; y += 2) {
         const uint8_t* line = bmp->line[y];
+        int dst_y = y + frame_y;
+        int dst_x = frame_x;
         for (int x = 0; x < frame_width; x++) {
-            uint8_t index = line[x];
-            uint16_t color = nesPalette[index];
-            canvas->writePixelPreclipped(x + frame_x, y + frame_y, color);
-            // app->canvas->drawPixel(x + frame_x, y + frame_y, color);
+            canvas->writePixelPreclipped(dst_x + x, dst_y, nesPalette[line[x]]);
+            // app->canvas->drawPixel(dst_x + x, dst_y, nesPalette[line[x]]);
         }
     }
     odd = !odd;
 #else
-    for (int y = 0; y < frame_height; y++) {
-        const uint8_t* line = bmp->line[y];
-        for (int x = 0; x < frame_width; x++) {
-            uint8_t index = line[x];
-            uint16_t color = nesPalette[index];
-            canvas->writePixelPreclipped(x + frame_x, y + frame_y, color);
-            // app->canvas->drawPixel(x + frame_x, y + frame_y, color);
-        }
+    auto rotation = canvas->getRotation();
+    auto fb = canvas->getFramebuffer();
+    int w = canvas->width();
+    int h = canvas->height();
+
+    switch (rotation) {
+        case 0: // no rotation
+            for (int y = 0; y < frame_height; y++) {
+                const uint8_t* src = bmp->line[y];
+                uint16_t* dst = fb + (frame_y + y) * w + frame_x;
+                for (int x = 0; x < frame_width; x++) {
+                    dst[x] = nesPalette[src[x]];
+                }
+            }
+            break;
+
+        case 1: // 90° clockwise
+            for (int y = 0; y < frame_height; y++) {
+                const uint8_t* src = bmp->line[y];
+                int py = frame_y + y;
+                for (int x = 0; x < frame_width; x++) {
+                    int px = frame_x + x;
+                    fb[px * w + (h - 1 - py)] = nesPalette[src[x]];
+                }
+            }
+            break;
+
+        case 2: // 180°
+            for (int y = 0; y < frame_height; y++) {
+                const uint8_t* src = bmp->line[y];
+                int py = frame_y + y;
+                for (int x = 0; x < frame_width; x++) {
+                    int px = frame_x + x;
+                    fb[(h - 1 - py) * w + (w - 1 - px)] = nesPalette[src[x]];
+                }
+            }
+            break;
+
+        case 3: // 270° clockwise
+            for (int y = 0; y < frame_height; y++) {
+                const uint8_t* src = bmp->line[y];
+                int py = frame_y + y;
+                for (int x = 0; x < frame_width; x++) {
+                    int px = frame_x + x;
+                    fb[(w - 1 - px) * w + py] = nesPalette[src[x]];
+                }
+            }
+            break;
     }
+
+        // for (int y = 0; y < frame_height; y++) {
+        //     const uint8_t* line = bmp->line[y];
+        //     int dst_y = y + frame_y;
+        //     int dst_x = frame_x;
+        //     for (int x = 0; x < frame_width; x++) {
+        //         canvas->writePixelPreclipped(dst_x + x, dst_y, nesPalette[line[x]]);
+        //         // app->canvas->drawPixel(dst_x + x, dst_y, nesPalette[line[x]]);
+        //     }
+        // }
 #endif
 
     // Serial.println("Draw 1 took " + String(micros() - last_render) + "us");


### PR DESCRIPTION
we could use canvas framebuffer directly, instead of writing pixel by pixel, it saves some time while rendering frame

didn't checked other rotations, but one used specifically in lilka works