### PR TITLE
fixed wrong path in cppcheck exclude dirs for dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clang-format: ## Run clang-format check
 
 .PHONY: cppcheck
 cppcheck: ## Run cppcheck check
-	$(CPPCHECK) . -i.ccls-cache -ipio -idoomgeneric -ibak -imJS -iSimpleFTPServer -iLodePNG \
+	$(CPPCHECK) . -i.ccls-cache -i.pio -idoomgeneric -ibak -imJS -iSimpleFTPServer -iLodePNG \
 		--enable=performance,style \
 		--suppress=knownPointerToBool \
 		--suppress=noCopyConstructor \


### PR DESCRIPTION
Wrong path was used for excluding dependencies from checking in cppcheck