### PR TITLE
lua serial temporary serial rx buffer enlargement hack to read big files

### DIFF
--- a/src/apps/lua/luarunner.h
+++ b/src/apps/lua/luarunner.h
@@ -4,6 +4,17 @@
 #include <lua.hpp>
 #include "keira/app.h"
 
+// Enlarge this buffer if u've problems with Live Lua
+#ifndef LUA_SERIAL_TEMPORARY_BUFFER_RX_SIZE
+#    define LUA_SERIAL_TEMPORARY_BUFFER_RX_SIZE 32768
+#endif
+
+#ifdef LUA_LIVE_DEBUG
+#    define LUA_DBG if (1)
+#else
+#    define LUA_DBG if (0)
+#endif
+
 // Abstract Lua runner app. Sets up Lua VM and provides a method to run Lua code.
 // Does not implement the run method.
 class AbstractLuaRunnerApp : public App {


### PR DESCRIPTION
Thing always reads not more than 256 bytes. Enlarge serial buff to fit file. Stick to 32 kb, then reduce to normal rx buffer size.

added env variable LUA_SERIAL_TEMPORARY_BUFFER_RX_SIZE to control size of buffer