### PR TITLE
Avoid deadlock in AppManager

### DIFF
--- a/src/apps/fmanager/fmanager.cpp
+++ b/src/apps/fmanager/fmanager.cpp
@@ -334,7 +334,6 @@ void FileManagerApp::openCurrentEntry() {
             FT_DEFAULT_OTHER_HANDLER;
             break;
     }
-    vTaskDelay(SUSPEND_AWAIT_TIME / portTICK_RATE_MS);
     changeMode(FM_MODE_RELOAD);
     exitChildDialogs = true;
 }

--- a/src/apps/fmanager/fmanager.h
+++ b/src/apps/fmanager/fmanager.h
@@ -62,12 +62,9 @@
 // MISC SETTINGS:  ////////////////////////////////////////////////////////////////////////////////////
 #define PROGRESS_FRAME_TIME              30
 #define PROGRESS_FILE_LIST_NO_DRAW_COUNT 10
-// There's a big chance, that task won't be suspended immediately, which could cause a bug
-// If ui hangs up after trying to open file, increase this value. TODO: implent this in AppManager
-#define SUSPEND_AWAIT_TIME         100
-#define FM_CHUNK_SIZE              256
-#define FM_MKDIR_MODE              0777
-#define FM_DEFAULT_NEW_FOLDER_NAME "New Folder"
+#define FM_CHUNK_SIZE                    256
+#define FM_MKDIR_MODE                    0777
+#define FM_DEFAULT_NEW_FOLDER_NAME       "New Folder"
 
 // STATUS BAR SETTINGS:  //////////////////////////////////////////////////////////////////////////////
 #define STATUS_BAR_HEIGHT        30

--- a/src/keira/appmanager.h
+++ b/src/keira/appmanager.h
@@ -1,5 +1,4 @@
-#ifndef MAIN_APPMANAGER_H
-#define MAIN_APPMANAGER_H
+#pragma once
 
 #include <Arduino.h>
 #include <lilka.h>
@@ -10,6 +9,8 @@ class AppManager {
 public:
     ~AppManager();
     void setPanel(App* app);
+    // adds app to appsToRun list, actuall runing happens
+    // inside loop
     void runApp(App* app);
     void loop();
     void renderToCanvas(lilka::Canvas* canvas);
@@ -24,6 +25,7 @@ private:
 
     App* panel;
     std::vector<App*> apps;
+    std::vector<App*> appsToRun;
     static AppManager* instance;
     SemaphoreHandle_t lock;
 
@@ -31,5 +33,3 @@ private:
     uint64_t toastStartTime;
     uint64_t toastEndTime;
 };
-
-#endif // MAIN_APPMANAGER_H


### PR DESCRIPTION
Previous code would stuck in case a new born app exits too fast