### PR TITLE
increase screenshot service priority

### DIFF
--- a/src/services/screenshot/screenshot.cpp
+++ b/src/services/screenshot/screenshot.cpp
@@ -96,6 +96,7 @@ private:
 
 ScreenshotService::ScreenshotService() : Service("screenshot") {
     setktStackSize(8192);
+    setktPriority(KT_PRIO_DEFAULT);
 }
 
 bool ScreenshotService::saveScreenshot(lilka::Canvas* canvas) {


### PR DESCRIPTION
All services now run in KT_PRIO_IDLE, but screenshot service specifically requires a bit higher priority for smooth operation.

This patch reduces delay between moment when buttons pressed by user and actual screenshot been taken